### PR TITLE
Unmarshal Media interface

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/99designs/gqlgen v0.17.34
-	github.com/vektah/gqlparser/v2 v2.5.6
+	github.com/mitchellh/mapstructure v1.5.0
 	gopkg.in/guregu/null.v4 v4.0.0
 )
 
@@ -13,6 +13,7 @@ require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/urfave/cli/v2 v2.25.7 // indirect
+	github.com/vektah/gqlparser/v2 v2.5.6 // indirect
 	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
 	golang.org/x/mod v0.12.0 // indirect
 	golang.org/x/sys v0.10.0 // indirect

--- a/graph/model/types.go
+++ b/graph/model/types.go
@@ -1,6 +1,18 @@
 package model
 
-import "gopkg.in/guregu/null.v4"
+import (
+	"fmt"
+	"reflect"
+	"regexp"
+
+	"gopkg.in/guregu/null.v4"
+)
+
+var gidRegex *regexp.Regexp
+
+func init() {
+	gidRegex = regexp.MustCompile(`^gid://shopify/(\w+)/\d+$`)
+}
 
 func NewNullString(v null.String) *null.String {
 	return &v
@@ -20,4 +32,24 @@ func NewInt(v int) *int {
 
 func NewFloat64(v float64) *float64 {
 	return &v
+}
+
+func concludeObjectType(gid string) (reflect.Type, error) {
+	submatches := gidRegex.FindStringSubmatch(gid)
+	if len(submatches) != 2 {
+		return reflect.TypeOf(nil), fmt.Errorf("malformed gid=`%s`", gid)
+	}
+	resource := submatches[1]
+	switch resource {
+	case "MediaImage":
+		return reflect.TypeOf(MediaImage{}), nil
+	case "Video":
+		return reflect.TypeOf(Video{}), nil
+	case "Model3d":
+		return reflect.TypeOf(Model3d{}), nil
+	case "ExternalVideo":
+		return reflect.TypeOf(ExternalVideo{}), nil
+	default:
+		return reflect.TypeOf(nil), fmt.Errorf("`%s` not implemented type", resource)
+	}
 }

--- a/graph/model/unmarshal.go
+++ b/graph/model/unmarshal.go
@@ -1,0 +1,78 @@
+package model
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+
+	"github.com/mitchellh/mapstructure"
+)
+
+func (s *MediaEdge) UnmarshalJSON(b []byte) error {
+	var m map[string]interface{}
+	err := json.Unmarshal(b, &m)
+	if err != nil {
+		return err
+	}
+	if cursor, ok := m["cursor"].(string); ok {
+		s.Cursor = cursor
+	}
+	if node, ok := m["node"].(map[string]interface{}); ok {
+		s.Node, err = decodeMedia(node)
+		if err != nil {
+			return fmt.Errorf("decode media node: %w", err)
+		}
+	}
+	return nil
+}
+
+func (s *MediaConnection) UnmarshalJSON(b []byte) error {
+	var (
+		m     map[string]interface{}
+		mConn struct {
+			Edges    []MediaEdge `json:"edges,omitempty"`
+			PageInfo *PageInfo   `json:"pageInfo,omitempty"`
+		}
+	)
+	err := json.Unmarshal(b, &mConn)
+	if err != nil {
+		return err
+	}
+	s.Edges = mConn.Edges
+	s.PageInfo = mConn.PageInfo
+
+	err = json.Unmarshal(b, &m)
+	if err != nil {
+		return err
+	}
+	if nodes, ok := m["nodes"].([]interface{}); ok {
+		s.Nodes = make([]Media, len(nodes))
+		for i, n := range nodes {
+			if node, ok := n.(map[string]interface{}); ok {
+				s.Nodes[i], err = decodeMedia(node)
+				if err != nil {
+					return fmt.Errorf("decode media node: %w", err)
+				}
+			} else {
+				return fmt.Errorf("expected type map[string]interface{} for Media node, got %T", n)
+			}
+		}
+	}
+	return nil
+}
+
+func decodeMedia(node map[string]interface{}) (Media, error) {
+	if id, ok := node["id"].(string); ok {
+		mediaType, err := concludeObjectType(id)
+		if err != nil {
+			return nil, fmt.Errorf("conclude object type: %w", err)
+		}
+		media := reflect.New(mediaType).Interface()
+		err = mapstructure.Decode(node, media)
+		if err != nil {
+			return nil, fmt.Errorf("decode media node: %w", err)
+		}
+		return media.(Media), nil
+	}
+	return nil, fmt.Errorf("must query id to decode Media")
+}


### PR DESCRIPTION
Since [gqlgen](https://github.com/99designs/gqlgen) generates Go interfaces for GraphQL interfaces, leading to an error when unmarshalling JSON data contains interface types. This pull request introduces custom `UnmarshalJSON` methods to unmarshal `Media` interface.

Related issue: https://github.com/99designs/gqlgen/issues/2446

Example query with this issue:
```
query products {
	products(first: 10) {
		id
		title
		handle
		media {
			edges {
				node {
					mediaContentType
					...on MediaImage {
						id
						alt
						mimeType
						image {
							height
							src
							width
						}
					}
					...on Model3d {
						id
						alt
						originalSource {
							url
							format
							filesize
							mimeType
						}
						preview {
							image {
								src
							}
						}
					}
					...on Video {
						id
						alt
						duration
						originalSource {
							url
							format
							mimeType
 							height
							width
						}
						preview {
							image {
								src
							}
						}
					}
					...on ExternalVideo {
						id
						originUrl
						embedUrl
						preview {
							image {
								src
							}
						}
					}
				}
			}
		}
	}
}
```
